### PR TITLE
add version requirement for go

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -14,7 +14,7 @@ You need these dependencies:
  - gst-plugin-gtk
  - gst-plugins-good
  - hidapi
- - go
+ - go >= 1.20
  
 # Building
 


### PR DESCRIPTION
The -C flag for the `go build` command was only added in go version 1.20