### PR TITLE
Add flake.nix to usbkvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.kate-swp
 *.drawio.bkp
 *.drawio.dtmp
+result*

--- a/flake-app-meson.patch
+++ b/flake-app-meson.patch
@@ -1,0 +1,17 @@
+diff --git a/app/meson.build b/app/meson.build
+index 6e60b0b..1515f76 100644
+--- a/app/meson.build
++++ b/app/meson.build
+@@ -124,8 +124,8 @@ keymap_h = custom_target(
+ mslib = custom_target(
+     'mslib',
+     output: ['mslib.a', 'mslib.h'],
+-    input: 'ms-tools/lib/mslib.go',
+-    command: ['go', 'build', '-C',  join_paths(meson.current_source_dir(), 'ms-tools/lib'), '-o', join_paths(meson.current_build_dir(), '@OUTPUT0@'), '-buildmode=c-archive', 'mslib.go']
++    input: ['mslib/mslib.a', 'mslib/mslib.h'],
++    command: ['cp', '@INPUT@', '.']
+     
+ )
+ 
+
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735523292,
+        "narHash": "sha256-opBsbR/nrGxiiF6XzlVluiHYb6yN/hEwv+lBWTy9xoM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6d97d419e5a9b36e6293887a89a078cf85f5a61b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,24 @@
         inherit system;
       };
     in rec {
+      mslib = pkgs.buildGoModule {
+        pname = "mslib";
+        version = "0.0.1";
+
+        src = ./. + "/app/ms-tools";
+
+        buildInputs = with pkgs; [
+          hidapi
+        ];
+
+        buildPhase = ''
+          mkdir -p $out
+          go build -C lib -o $out -buildmode=c-archive mslib.go
+        '';
+
+        vendorHash = "sha256-imHpsos7RDpATSZFWRxug67F7VgjRTT1SkLt7cWk6tU=";
+      };
+
       usbkvm-udev = pkgs.runCommand "usbkvm-udev" {} ''
         mkdir -p $out/lib/udev/rules.d
         cp ${./app}/70-usbkvm.rules $out/lib/udev/rules.d

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+  };
+  outputs = { self, nixpkgs, ... }: {
+    packages = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in rec {
+      usbkvm-udev = pkgs.runCommand "usbkvm-udev" {} ''
+        mkdir -p $out/lib/udev/rules.d
+        cp ${./app}/70-usbkvm.rules $out/lib/udev/rules.d
+      '';
+    });
+
+    hydraJobs = {
+      inherit (self)
+        packages;
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,29 @@
         inherit system;
       };
     in rec {
+      usbkvm-fw = pkgs.stdenv.mkDerivation rec {
+        pname = "usbkvm-fw";
+        version = "0.0.1";
+
+        src = nixpkgs.lib.cleanSource ./.;
+
+        sourceRoot = "${src.name}/fw/usbkvm";
+
+        nativeBuildInputs = with pkgs; [
+          gcc-arm-embedded
+          python3
+        ];
+
+        postPatch = ''
+          patchShebangs --build write_header.py
+        '';
+
+        installPhase = ''
+          mkdir -p $out
+          cp -r build/* $out
+        '';
+      };
+
       mslib = pkgs.buildGoModule {
         pname = "mslib";
         version = "0.0.1";


### PR DESCRIPTION
Builds the usbkvm app and usbkvm firmware with nix.

Currently I only made it build and running. I haven't tested if it actually works with the hardware attached.

Please try it and give feedback if you were successful:

```
git clone https://github.com/clerie/usbkvm.git
cd usbkvm
git switch nix-flake
git submodule init
git submodule update
nix run .?submodules=1
```

Maybe someone finds out how to handle git submodules a little more transparent in with nix.

Also I appreciate help with integrating this into the meson.build, as patching should not be necessary I think.